### PR TITLE
Use relative path for gen_assets.go, fix the multi-GOPATH issue

### DIFF
--- a/assets/mappings.go
+++ b/assets/mappings.go
@@ -78,8 +78,7 @@ func (d _GoPkgMappingDumper) Dump(mapping *AssetsMapping) error {
 	if pkgName == "" || pkgName == "." || pkgName == "main" {
 		pkgName = "main"
 	} else {
-		goPath := os.Getenv("GOPATH")
-		targetPath = path.Join(goPath, "src", pkgName, "assets_gen.go")
+		targetPath = "./web/assets_gen.go"
 		pkgName = path.Base(pkgName)
 	}
 	mapping.PkgName = pkgName


### PR DESCRIPTION
GOPATH can be consisted with multiple paths, in this case gen_assets.go cannot be created.
Use relative path can fix this.
